### PR TITLE
Apply filters in threads with a highlighted post

### DIFF
--- a/content_scripts/thread.js
+++ b/content_scripts/thread.js
@@ -35,7 +35,7 @@ observer.observe(document.querySelector('.thread'), { childList: true });
 
 chrome.runtime.onMessage.addListener(({ cmd }) => {
   if (cmd === 'reapplyFilters') {
-    const threadNo = document.location.pathname.match(/\/thread\/(\d+)\//)[1];
+    const threadNo = document.location.pathname.match(/\/thread\/(\d+)/)[1];
     const thread = loadThread(threadNo);
     showNormalPosts(thread);
     hideMemePosts(thread);


### PR DESCRIPTION
Due to a wrong regular expression filters weren't applied in threads
where a post was highlighted.

Close #21 